### PR TITLE
Client socket disconnect.

### DIFF
--- a/lib/ClientSocket.js
+++ b/lib/ClientSocket.js
@@ -8,6 +8,10 @@ ClientSocket.prototype = Object.create(EventEmitter.prototype);
 
 ClientSocket.prototype.constructor = ClientSocket;
 
+ClientSocket.prototype.disconnect = function () {
+	this.emit("disconnect");
+};
+
 ClientSocket.prototype.off = function (event, listener) {
 	if (listener) {
 		return ClientSocket.prototype.removeListener.call(this, event, listener);

--- a/lib/ServerSocket.js
+++ b/lib/ServerSocket.js
@@ -44,10 +44,6 @@ ServerSocket.prototype = Object.create(ClientSocket.prototype);
 
 ServerSocket.prototype.constructor = ServerSocket;
 
-ServerSocket.prototype.disconnect = function () {
-	this.emit("disconnect");
-};
-
 ServerSocket.prototype.join = function (name) {
 	this.adapter.add(this.id, name);
 	this.rooms.push(name);

--- a/test/sockets_spec.js
+++ b/test/sockets_spec.js
@@ -165,3 +165,30 @@ describe("A socket connection initiating a disconnect from the server", function
 		expect(disconnect.callCount, "disconnect").to.equal(1);
 	});
 });
+
+describe("A socket connection initiating a disconnect from the client", function () {
+	var disconnect;
+	var socket;
+
+	before(function (done) {
+		var server = new Server();
+		var client = new Client(server);
+
+		disconnect = sinon.spy(done);
+
+		server.once("connection", function (connection) {
+			socket = connection;
+			socket.once("disconnect", disconnect);
+		});
+
+		client.connect().disconnect();
+	});
+
+	after(function () {
+		socket.removeListener("disconnect", disconnect);
+	});
+
+	it("emits the 'disconnect' event on the server", function () {
+		expect(disconnect.callCount, "disconnect").to.equal(1);
+	});
+});


### PR DESCRIPTION
Provides the `disconnect()` method for client sockets. This is needed for inetCatapult/shortwave#122.
