### PR TITLE
Respect middleware errors.

### DIFF
--- a/lib/Namespace.js
+++ b/lib/Namespace.js
@@ -1,5 +1,6 @@
 "use strict";
 var Adapter      = require("./Adapter");
+var EventEmitter = require("events").EventEmitter;
 var ServerSocket = require("./ServerSocket");
 
 function createBridge (client, server) {
@@ -11,6 +12,8 @@ function createBridge (client, server) {
 }
 
 function Namespace (server, name) {
+	EventEmitter.call(this);
+
 	this.adapter = new Adapter(this);
 	this.fns     = [];
 	this.name    = name;
@@ -18,21 +21,26 @@ function Namespace (server, name) {
 	this.sockets = [];
 }
 
+Namespace.prototype             = Object.create(EventEmitter.prototype);
+Namespace.prototype.constructor = Namespace;
+
 Namespace.prototype.add = function (client) {
 	var self   = this;
 	var socket = new ServerSocket(this);
 
-	createBridge(client, socket);
 	this.run(socket, function (error) {
 		if (error) {
-			socket.emit("error", error.message);
+			client.emit("error", error.message);
 			return;
 		}
 		else {
+			createBridge(client, socket);
 			self.sockets.push(socket);
+			self.emit("connection", socket);
 			return;
 		}
 	});
+
 	return socket;
 };
 

--- a/lib/Namespace.js
+++ b/lib/Namespace.js
@@ -22,7 +22,7 @@ Namespace.prototype.add = function (client) {
 	var socket = new ServerSocket(this);
 
 	createBridge(client, socket);
-	this.run(socket);
+	this.run(socket, function () {});
 	this.sockets.push(socket);
 	return socket;
 };
@@ -35,14 +35,24 @@ Namespace.prototype.remove = function (socket) {
 	}
 };
 
-Namespace.prototype.run = function (socket) {
+Namespace.prototype.run = function (socket, callback) {
 	var middleware = this.fns.slice();
 
-	(function next () {
+	(function next (error) {
 		var fn = middleware.shift();
+
+		if (error) {
+			callback(error);
+			return;
+		}
 
 		if (fn) {
 			fn(socket, next);
+			return;
+		}
+		else {
+			callback(null);
+			return;
 		}
 	})();
 };

--- a/lib/Namespace.js
+++ b/lib/Namespace.js
@@ -19,11 +19,20 @@ function Namespace (server, name) {
 }
 
 Namespace.prototype.add = function (client) {
+	var self   = this;
 	var socket = new ServerSocket(this);
 
 	createBridge(client, socket);
-	this.run(socket, function () {});
-	this.sockets.push(socket);
+	this.run(socket, function (error) {
+		if (error) {
+			socket.emit("error", error.message);
+			return;
+		}
+		else {
+			self.sockets.push(socket);
+			return;
+		}
+	});
 	return socket;
 };
 

--- a/lib/Namespace.js
+++ b/lib/Namespace.js
@@ -30,7 +30,9 @@ Namespace.prototype.add = function (client) {
 
 	this.run(socket, function (error) {
 		if (error) {
-			client.emit("error", error.message);
+			// Need to wait for the next tick or else the error will be emitted
+			// before the client returns the socket to the consumer.
+			process.nextTick(client.emit.bind(client, "error", error.message));
 			return;
 		}
 		else {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -6,11 +6,12 @@ var Namespace    = require("./Namespace");
 function Server () {
 	this.sockets = new Namespace(this, "/");
 
+	this.sockets.on("connection", this.emit.bind(this, "connection"));
+
 	this.createSocket = function () {
 		var clientSocket = new ClientSocket();
-		var serverSocket = this.sockets.add(clientSocket);
 
-		this.emit("connection", serverSocket);
+		this.sockets.add(clientSocket);
 		return clientSocket;
 	};
 

--- a/test/Namespace_spec.js
+++ b/test/Namespace_spec.js
@@ -112,18 +112,20 @@ describe("A namespace", function () {
 			var client     = new ClientSocket();
 			var connection = sinon.spy();
 			var error      = new Error("Simulated failure.");
-			var failure    = sinon.spy();
 
+			var failure;
 			var run;
 			var socket;
 
-			before(function () {
+			before(function (done) {
 				run = sinon.stub(namespace, "run");
 				run.callsArgWith(1, error);
 
 				namespace.once("connection", connection);
 
+				failure = sinon.spy(done.bind(null, null));
 				client.once("error", failure);
+
 				socket = namespace.add(client);
 			});
 


### PR DESCRIPTION
This change causes the namespace to reject sockets that do not satisfy the middleware constraints. This is needed to support testing for inetCatapult/shortwave#126.
