### PR TITLE
require modules explicitly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,8 @@
 "use strict";
-var fs   = require("fs");
-var path = require("path");
 
-module.exports = fs.readdirSync(__dirname).reduce(
+module.exports = [ "Adapter", "Client", "ClientSocket", "Namespace", "Server", "ServerSocket" ].reduce(
 	function (modules, name) {
-		if (name !== "index.js") {
-			modules[path.basename(name, ".js")] = require("./" + name);
-		}
+		modules[name] = require("./" + name);
 		return modules;
 	},
 	{}


### PR DESCRIPTION
Avoiding the use of `fs` makes this easier to use in a client-side environment with Browserify or Webpack.

substack/brfs#19